### PR TITLE
Check return code of cowboy:start_listener().

### DIFF
--- a/examples/cowboy_echo.erl
+++ b/examples/cowboy_echo.erl
@@ -22,9 +22,9 @@ main(_) ->
     Routes = [{'_',  VhostRoutes}], % any vhost
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     Port}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+    {ok, _} = cowboy:start_listener(http, 100,
+                                    cowboy_tcp_transport, [{port,     Port}],
+                                    cowboy_http_protocol, [{dispatch, Routes}]),
     receive
         _ -> ok
     end.

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -42,9 +42,9 @@ main(_) ->
     Routes = [{'_',  VRoutes}], % any vhost
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     Port}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+    {ok, _} = cowboy:start_listener(http, 100,
+                                    cowboy_tcp_transport, [{port,     Port}],
+                                    cowboy_http_protocol, [{dispatch, Routes}]),
     receive
         _ -> ok
     end.


### PR DESCRIPTION
When cowboy:start_listener() has an error it is returned. This value
should be checked so errors like eaddrinuse can be detected.
