### PR TITLE
Support allowed origins for XHR_COR

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ like this:
 
 ```erlang
 main(_) ->
+    application:start(ranch),
     application:start(sockjs),
     application:start(cowboy),
 
@@ -37,9 +38,9 @@ main(_) ->
     Routes = [{'_',  [{[<<"echo">>, '...'],
                        sockjs_cowboy_handler, SockjsState}]}],
 
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     8081}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+    cowboy:start_http(listener, 100, [{port, 8081}],
+      [{dispatch, Routes}]),
+
     receive
         _ -> ok
     end.

--- a/examples/cowboy_echo.erl
+++ b/examples/cowboy_echo.erl
@@ -11,6 +11,7 @@
 
 main(_) ->
     Port = 8081,
+    application:start(ranch),
     application:start(sockjs),
     application:start(cowboy),
 
@@ -22,9 +23,8 @@ main(_) ->
     Routes = [{'_',  VhostRoutes}], % any vhost
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     Port}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+    cowboy:start_http(listener, 100, [{port, Port}],
+      [{dispatch, Routes}]),
     receive
         _ -> ok
     end.
@@ -36,7 +36,7 @@ init({_Any, http}, Req, []) ->
 
 handle(Req, State) ->
     {ok, Data} = file:read_file("./examples/echo.html"),
-    {ok, Req1} = cowboy_http_req:reply(200, [{<<"Content-Type">>, "text/html"}],
+    {ok, Req1} = cowboy_req:reply(200, [{<<"Content-Type">>, "text/html"}],
                                        Data, Req),
     {ok, Req1, State}.
 

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -11,6 +11,7 @@
 
 main(_) ->
     Port = 8081,
+    application:start(ranch),
     application:start(sockjs),
     application:start(cowboy),
 

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -42,9 +42,8 @@ main(_) ->
     Routes = [{'_',  VRoutes}], % any vhost
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     Port}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+    cowboy:start_http(listener, 100, 
+      [{port, Port}], [{dispatch, Routes}]),
     receive
         _ -> ok
     end.
@@ -55,7 +54,7 @@ init({_Any, http}, Req, []) ->
     {ok, Req, []}.
 
 handle(Req, State) ->
-    {ok, Req2} = cowboy_http_req:reply(404, [],
+    {ok, Req2} = cowboy_req:reply(404, [],
                  <<"404 - Nothing here (via sockjs-erlang fallback)\n">>, Req),
     {ok, Req2, State}.
 

--- a/examples/multiplex/cowboy_multiplex.erl
+++ b/examples/multiplex/cowboy_multiplex.erl
@@ -39,7 +39,7 @@ init({_Any, http}, Req, []) ->
     {ok, Req, []}.
 
 handle(Req, State) ->
-    {Path, Req1} = cowboy_req:path(Req),
+    {Path, Req1} = cowboy_req:raw_path(Req),
     {ok, Req2} = case Path of
                      [<<"multiplex.js">>] ->
                          {ok, Data} = file:read_file("./examples/multiplex/multiplex.js"),

--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
 
 {deps, [
         {cowboy, ".*",
-         {git, "git://github.com/extend/cowboy.git", "4fb2a6face6e7d6ff1dd34a02c3bd8b63d972624"}}
+         {git, "git://github.com/extend/cowboy.git", "981ea359ba23564cb9bc3056a56dfcd1a98aa362"}}
        ]}.

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -1,6 +1,6 @@
 -module(sockjs_cowboy_handler).
 -behaviour(cowboy_http_handler).
--behaviour(cowboy_http_websocket_handler).
+-behaviour(cowboy_websocket_handler).
 
 %% Cowboy http callbacks
 -export([init/3, handle/2, terminate/2]).
@@ -16,7 +16,7 @@
 init({_Any, http}, Req, Service) ->
     case sockjs_handler:is_valid_ws(Service, {cowboy, Req}) of
         {true, {cowboy, _Req1}, _Reason} ->
-            {upgrade, protocol, cowboy_http_websocket};
+            {upgrade, protocol, cowboy_websocket};
         {false, {cowboy, Req1}, _Reason} ->
             {ok, Req1, Service}
     end.

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -244,7 +244,7 @@ origin_allowed(Origin, Origins) ->
             RegEx = "^" ++ Allowed,
             RegEx1 = re:replace(RegEx, "\\*", ".*", [{return,list}]),
             RegEx2 = re:replace(RegEx1, "\\?", ".", [{return,list}]),
-            RegEx3 = [RegEx2|"$"],
+            RegEx3 = RegEx2 ++ "$",
             case re:run(Origin, RegEx3) of
                 nomatch -> false;
                 {match, _} -> true

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -9,15 +9,15 @@
 %% --------------------------------------------------------------------------
 
 -spec path(req()) -> {string(), req()}.
-path({cowboy, Req})       -> {Path, Req1} = cowboy_http_req:raw_path(Req),
+path({cowboy, Req})       -> {Path, Req1} = cowboy_req:path(Req),
                              {binary_to_list(Path), {cowboy, Req1}}.
 
 -spec method(req()) -> {atom(), req()}.
-method({cowboy, Req})       -> {Method, Req1} = cowboy_http_req:method(Req),
+method({cowboy, Req})       -> {Method, Req1} = cowboy_req:method(Req),
                                {Method, {cowboy, Req1}}.
 
 -spec body(req()) -> {binary(), req()}.
-body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_http_req:body(Req),
+body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_req:body(Req),
                              {Body, {cowboy, Req1}}.
 
 -spec body_qs(req()) -> {binary(), req()}.
@@ -31,7 +31,7 @@ body_qs(Req) ->
             body_qs2(Req1)
     end.
 body_qs2({cowboy, Req}) ->
-    {BodyQS, Req1} = cowboy_http_req:body_qs(Req),
+    {BodyQS, Req1} = cowboy_req:body_qs(Req),
     case proplists:get_value(<<"d">>, BodyQS) of
         undefined ->
             {<<>>, {cowboy, Req1}};
@@ -41,10 +41,10 @@ body_qs2({cowboy, Req}) ->
 
 -spec header(atom(), req()) -> {nonempty_string() | undefined, req()}.
 header(K, {cowboy, Req})->
-    {H, Req2} = cowboy_http_req:header(K, Req),
+    {H, Req2} = cowboy_req:header(K, Req),
     {V, Req3} = case H of
                     undefined ->
-                        cowboy_http_req:header(atom_to_binary(K, utf8), Req2);
+                        cowboy_req:header(atom_to_binary(K, utf8), Req2);
                     _ -> {H, Req2}
                 end,
     case V of
@@ -54,7 +54,7 @@ header(K, {cowboy, Req})->
 
 -spec jsessionid(req()) -> {nonempty_string() | undefined, req()}.
 jsessionid({cowboy, Req}) ->
-    {C, Req2} = cowboy_http_req:cookie(<<"JSESSIONID">>, Req),
+    {C, Req2} = cowboy_req:cookie(<<"JSESSIONID">>, Req),
     case C of
         _ when is_binary(C) ->
             {binary_to_list(C), {cowboy, Req2}};
@@ -64,7 +64,7 @@ jsessionid({cowboy, Req}) ->
 
 -spec callback(req()) -> {nonempty_string() | undefined, req()}.
 callback({cowboy, Req}) ->
-    {CB, Req1} = cowboy_http_req:qs_val(<<"c">>, Req),
+    {CB, Req1} = cowboy_req:qs_val(<<"c">>, Req),
     case CB of
         undefined -> {undefined, {cowboy, Req1}};
         _         -> {binary_to_list(CB), {cowboy, Req1}}
@@ -72,12 +72,12 @@ callback({cowboy, Req}) ->
 
 -spec peername(req()) -> {{inet:ip_address(), non_neg_integer()}, req()}.
 peername({cowboy, Req}) ->
-    {P, Req1} = cowboy_http_req:peer(Req),
+    {P, Req1} = cowboy_req:peer(Req),
     {P, {cowboy, Req1}}.
 
 -spec sockname(req()) -> {{inet:ip_address(), non_neg_integer()}, req()}.
 sockname({cowboy, Req} = R) ->
-    {ok, _T, S} = cowboy_http_req:transport(Req),
+    {ok, _T, S} = cowboy_req:transport(Req),
     %% Cowboy has peername(), but doesn't have sockname() equivalent.
     {ok, Addr} = case S of
                      _ when is_port(S) ->
@@ -92,17 +92,17 @@ sockname({cowboy, Req} = R) ->
 -spec reply(non_neg_integer(), headers(), iodata(), req()) -> req().
 reply(Code, Headers, Body, {cowboy, Req}) ->
     Body1 = iolist_to_binary(Body),
-    {ok, Req1} = cowboy_http_req:reply(Code, enbinary(Headers), Body1, Req),
+    {ok, Req1} = cowboy_req:reply(Code, enbinary(Headers), Body1, Req),
     {cowboy, Req1}.
 
 -spec chunk_start(non_neg_integer(), headers(), req()) -> req().
 chunk_start(Code, Headers, {cowboy, Req}) ->
-    {ok, Req1} = cowboy_http_req:chunked_reply(Code, enbinary(Headers), Req),
+    {ok, Req1} = cowboy_req:chunked_reply(Code, enbinary(Headers), Req),
     {cowboy, Req1}.
 
 -spec chunk(iodata(), req()) -> {ok | error, req()}.
 chunk(Chunk, {cowboy, Req} = R) ->
-    case cowboy_http_req:chunk(Chunk, Req) of
+    case cowboy_req:chunk(Chunk, Req) of
         ok          -> {ok, R};
         {error, _E} -> {error, R}
                       %% This shouldn't happen too often, usually we
@@ -117,18 +117,18 @@ enbinary(L) -> [{list_to_binary(K), list_to_binary(V)} || {K, V} <- L].
 
 -spec hook_tcp_close(req()) -> req().
 hook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_http_req:transport(Req),
+    {ok, T, S} = cowboy_req:transport(Req),
     T:setopts(S,[{active,once}]),
     R.
 
 -spec unhook_tcp_close(req()) -> req().
 unhook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_http_req:transport(Req),
+    {ok, T, S} = cowboy_req:transport(Req),
     T:setopts(S,[{active,false}]),
     R.
 
 -spec abruptly_kill(req()) -> req().
 abruptly_kill(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_http_req:transport(Req),
+    {ok, T, S} = cowboy_req:transport(Req),
     T:close(S),
     R.

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -9,7 +9,7 @@
 %% --------------------------------------------------------------------------
 
 -spec path(req()) -> {string(), req()}.
-path({cowboy, Req})       -> {Path, Req1} = cowboy_req:path(Req),
+path({cowboy, Req})       -> {Path, Req1} = cowboy_req:raw_path(Req),
                              {binary_to_list(Path), {cowboy, Req1}}.
 
 -spec method(req()) -> {atom(), req()}.
@@ -31,7 +31,7 @@ body_qs(Req) ->
             body_qs2(Req1)
     end.
 body_qs2({cowboy, Req}) ->
-    {BodyQS, Req1} = cowboy_req:body_qs(Req),
+    {ok, BodyQS, Req1} = cowboy_req:body_qs(Req),
     case proplists:get_value(<<"d">>, BodyQS) of
         undefined ->
             {<<>>, {cowboy, Req1}};

--- a/src/sockjs_internal.hrl
+++ b/src/sockjs_internal.hrl
@@ -12,6 +12,7 @@
                   sockjs_url       :: nonempty_string(),
                   cookie_needed    :: boolean(),
                   websocket        :: boolean(),
+                  origins          :: list(nonempty_string()),
                   disconnect_delay :: non_neg_integer(),
                   heartbeat_delay  :: non_neg_integer(),
                   response_limit   :: non_neg_integer(),


### PR DESCRIPTION
I feel the need of whitelisting origins in XHR_COR to add an extra security measure. I'm not sure why sockjs-erlang has not supported it yet.
