### PR TITLE
Add Cowboy 0.8.x Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ main(_) ->
 
 service_echo(_Conn, init, state)        -> {ok, state};
 service_echo(Conn, {recv, Data}, state) -> Conn:send(Data);
+service_echo(_Conn, {info, _Info}, state) -> {ok, state};
 service_echo(_Conn, closed, state)      -> {ok, state}.
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,11 @@ simple. It has just a couple of methods:
        after the client was last connected (in ms).
      * `{response_limit, integer()}` - the maximum size of a single
        http streaming response (in bytes).
-     * `{hib_timeout, integer()}` - hibernate websocket process after
-       hib_timeout milliseconds of inactivity (5000 by default) to
-       reduce memory footprint. (implementation is incomplete, see #15)
+     * `{hib_timeout, integer() | hibernate}` - hibernate websocket
+       process after hib_timeout milliseconds of inactivity (5000 by
+       default) to reduce memory footprint. Set to 'hibernate' atom to
+       hibernate always (may be inefficient). (implementation is
+       incomplete, see #15)
      * `{logger, fun/3}` - a function called on every request, used
        to print request to the logs (or on the screen by default).
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ simple. It has just a couple of methods:
        after the client was last connected (in ms).
      * `{response_limit, integer()}` - the maximum size of a single
        http streaming response (in bytes).
+     * `{hibernate, boolean()}` - set true to hibernate the websocket
+       process and save up memory and CPU. You should hibernate processes
+       that will receive few messages.
      * `{logger, fun/3}` - a function called on every request, used
        to print request to the logs (or on the screen by default).
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ simple. It has just a couple of methods:
        after the client was last connected (in ms).
      * `{response_limit, integer()}` - the maximum size of a single
        http streaming response (in bytes).
-     * `{hibernate, boolean()}` - set true to hibernate the websocket
-       process and save up memory and CPU. You should hibernate processes
-       that will receive few messages.
+     * `{timeout, integer() | hibernate}` - loop timeout. infinity by
+       default. Set hibernate atom to enable hibernation that can
+       reduce memory consumption.
      * `{logger, fun/3}` - a function called on every request, used
        to print request to the logs (or on the screen by default).
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ simple. It has just a couple of methods:
        after the client was last connected (in ms).
      * `{response_limit, integer()}` - the maximum size of a single
        http streaming response (in bytes).
-     * `{timeout, integer() | hibernate}` - loop timeout. infinity by
-       default. Set hibernate atom to enable hibernation that can
-       reduce memory consumption.
+     * `{hib_timeout, integer()}` - hibernate websocket process after
+       hib_timeout milliseconds of inactivity (5000 by default) to
+       reduce memory footprint. (implementation is incomplete, see #15)
      * `{logger, fun/3}` - a function called on every request, used
        to print request to the logs (or on the screen by default).
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ main(_) ->
                        sockjs_cowboy_handler, SockjsState}]}],
 
     cowboy:start_http(cowboy_test_http_listener, 100, 
-                      [{port, Port}],
+                      [{port, 8081}],
                       [{dispatch, Routes}]),
     receive
         _ -> ok

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ compatible with
 https://github.com/sockjs/sockjs-client for more information on
 SockJS.
 
+Minimalistic publish/subscribe integrated with sockjs-erlang: **[sockjs-pubsub](https://github.com/blinkov/sockjs-pubsub)**
+
 
 Show me the code!
 -----------------

--- a/README.md
+++ b/README.md
@@ -30,26 +30,29 @@ like this:
 
 ```erlang
 main(_) ->
-    application:start(sockjs),
-    application:start(cowboy),
+    ok = application:start(sockjs),
+    ok = application:start(ranch),
+    ok = application:start(crypto),
+    ok = application:start(cowboy),
 
     SockjsState = sockjs_handler:init_state(
                     <<"/echo">>, fun service_echo/3, state, []),
 
-    Routes = [{'_',  [{[<<"echo">>, '...'],
+    Routes = [{'_',  [{<<"/echo/[...]">>,
                        sockjs_cowboy_handler, SockjsState}]}],
+    Dispatch = cowboy_router:compile(Routes),
 
-    cowboy:start_http(cowboy_test_http_listener, 100, 
+    cowboy:start_http(cowboy_test_http_listener, 100,
                       [{port, 8081}],
-                      [{dispatch, Routes}]),
+                      [{env, [{dispatch, Dispatch}]}]),
     receive
         _ -> ok
     end.
 
-service_echo(_Conn, init, state)        -> {ok, state};
-service_echo(Conn, {recv, Data}, state) -> Conn:send(Data);
+service_echo(_Conn, init, state)          -> {ok, state};
+service_echo(Conn, {recv, Data}, state)   -> Conn:send(Data);
 service_echo(_Conn, {info, _Info}, state) -> {ok, state};
-service_echo(_Conn, closed, state)      -> {ok, state}.
+service_echo(_Conn, closed, state)        -> {ok, state}.
 ```
 
 Dig into the `examples` directory to get working code:

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ main(_) ->
     Routes = [{'_',  [{[<<"echo">>, '...'],
                        sockjs_cowboy_handler, SockjsState}]}],
 
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     8081}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+    cowboy:start_http(cowboy_test_http_listener, 100, 
+                      [{port, Port}],
+                      [{dispatch, Routes}]),
     receive
         _ -> ok
     end.

--- a/examples/cowboy_echo.erl
+++ b/examples/cowboy_echo.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -smp disable +A1 +K true -pa ebin deps/cowboy/ebin -input
+%%! -pa ebin deps/cowboy/ebin -input
 -module(cowboy_echo).
 -mode(compile).
 

--- a/examples/cowboy_echo.erl
+++ b/examples/cowboy_echo.erl
@@ -47,4 +47,5 @@ terminate(_Req, _State) ->
 
 service_echo(_Conn, init, state)        -> {ok, state};
 service_echo(Conn, {recv, Data}, state) -> Conn:send(Data);
+service_echo(Conn, {info, _Info}, state) -> {ok, state};
 service_echo(_Conn, closed, state)      -> {ok, state}.

--- a/examples/cowboy_echo.erl
+++ b/examples/cowboy_echo.erl
@@ -22,9 +22,9 @@ main(_) ->
     Routes = [{'_',  VhostRoutes}], % any vhost
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     Port}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+    {ok, _} = cowboy:start_listener(http, 100,
+                                    cowboy_tcp_transport, [{port,     Port}],
+                                    cowboy_http_protocol, [{dispatch, Routes}]),
     receive
         _ -> ok
     end.

--- a/examples/cowboy_echo.erl
+++ b/examples/cowboy_echo.erl
@@ -1,9 +1,6 @@
 #!/usr/bin/env escript
-<<<<<<< HEAD
 %%! -smp disable +A1 +K true -pa ebin -env ERL_LIBS deps -input
-=======
-%%! -pa ebin deps/cowboy/ebin -input
->>>>>>> 92d4ba4e41f6e110f97cb50ea0810e34e9b8ef4f
+
 -module(cowboy_echo).
 -mode(compile).
 

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -smp disable +A1 +K true -pa ebin deps/cowboy/ebin -input
+%%! -smp disable +A1 +K true -pa ebin -env ERL_LIBS deps -input
 -module(cowboy_test_server).
 -mode(compile).
 
@@ -11,8 +11,10 @@
 
 main(_) ->
     Port = 8081,
-    application:start(sockjs),
-    application:start(cowboy),
+    ok = application:start(sockjs),
+    ok = application:start(ranch),
+    ok = application:start(crypto),    
+    ok = application:start(cowboy),
 
     StateEcho = sockjs_handler:init_state(
                   <<"/echo">>, fun service_echo/3, state,
@@ -42,9 +44,10 @@ main(_) ->
     Routes = [{'_',  VRoutes}], % any vhost
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     Port}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+
+    cowboy:start_http(cowboy_test_server_http_listener, 100, 
+                      [{port, Port}],
+                      [{dispatch, Routes}]),
     receive
         _ -> ok
     end.
@@ -55,7 +58,7 @@ init({_Any, http}, Req, []) ->
     {ok, Req, []}.
 
 handle(Req, State) ->
-    {ok, Req2} = cowboy_http_req:reply(404, [],
+    {ok, Req2} = cowboy_req:reply(404, [],
                  <<"404 - Nothing here (via sockjs-erlang fallback)\n">>, Req),
     {ok, Req2, State}.
 

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -smp disable +A1 +K true -pa ebin deps/cowboy/ebin -input
+%%! -pa ebin deps/cowboy/ebin -input
 -module(cowboy_test_server).
 -mode(compile).
 

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -42,9 +42,9 @@ main(_) ->
     Routes = [{'_',  VRoutes}], % any vhost
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     Port}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+    {ok, _} = cowboy:start_listener(http, 100,
+                                    cowboy_tcp_transport, [{port,     Port}],
+                                    cowboy_http_protocol, [{dispatch, Routes}]),
     receive
         _ -> ok
     end.

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -1,9 +1,6 @@
 #!/usr/bin/env escript
-<<<<<<< HEAD
 %%! -smp disable +A1 +K true -pa ebin -env ERL_LIBS deps -input
-=======
-%%! -pa ebin deps/cowboy/ebin -input
->>>>>>> 92d4ba4e41f6e110f97cb50ea0810e34e9b8ef4f
+
 -module(cowboy_test_server).
 -mode(compile).
 

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -33,22 +33,23 @@ main(_) ->
                     <<"/cookie_needed_echo">>, fun service_echo/3, state,
                     [{cookie_needed, true}]),
 
-    VRoutes = [{[<<"echo">>, '...'], sockjs_cowboy_handler, StateEcho},
-               {[<<"close">>, '...'], sockjs_cowboy_handler, StateClose},
-               {[<<"amplify">>, '...'], sockjs_cowboy_handler, StateAmplify},
-               {[<<"broadcast">>, '...'], sockjs_cowboy_handler, StateBroadcast},
-               {[<<"disabled_websocket_echo">>, '...'], sockjs_cowboy_handler,
+    VRoutes = [{<<"/echo/[...]">>, sockjs_cowboy_handler, StateEcho},
+               {<<"/close/[...]">>, sockjs_cowboy_handler, StateClose},
+               {<<"/amplify/[...]">>, sockjs_cowboy_handler, StateAmplify},
+               {<<"/broadcast/[...]">>, sockjs_cowboy_handler, StateBroadcast},
+               {<<"/disabled_websocket_echo/[...]">>, sockjs_cowboy_handler,
                 StateDWSEcho},
-               {[<<"cookie_needed_echo">>, '...'], sockjs_cowboy_handler,
+               {<<"/cookie_needed_echo/[...]">>, sockjs_cowboy_handler,
                 StateCNEcho},
                {'_', ?MODULE, []}],
     Routes = [{'_',  VRoutes}], % any vhost
+    Dispatch = cowboy_router:compile(Routes),
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
 
     cowboy:start_http(cowboy_test_server_http_listener, 100, 
                       [{port, Port}],
-                      [{dispatch, Routes}]),
+                      [{env, [{dispatch, Dispatch}]}]),
     receive
         _ -> ok
     end.

--- a/examples/multiplex/cowboy_multiplex.erl
+++ b/examples/multiplex/cowboy_multiplex.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -smp disable +A1 +K true -pa ebin deps/cowboy/ebin -input
+%%! -pa ebin deps/cowboy/ebin -input
 -module(cowboy_multiplex).
 -mode(compile).
 

--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
 
 {deps, [
         {cowboy, ".*",
-         {git, "git://github.com/extend/cowboy.git", "4fb2a6face6e7d6ff1dd34a02c3bd8b63d972624"}}
+         {git, "git://github.com/extend/cowboy.git"}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,8 +4,8 @@
 
 {erl_opts, [
             %% fail_on_warning,
-            bin_opt_info,
-            warn_missing_spec,
+            %bin_opt_info,
+            %warn_missing_spec,
             debug_info,
             warn_export_all
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
 
 {deps, [
         %{cowboy, ".*", {git, "git://github.com/extend/cowboy.git", "master"}}
-        {cowboy, "0.5.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.5.0_changes_080412"}}}
+        {cowboy, "0.6.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.6.0_changes_270512"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,6 +11,6 @@
 ]}.
 
 {deps, [
-        {cowboy, ".*",
-         {git, "git://github.com/extend/cowboy.git", "master"}}
+        %{cowboy, ".*", {git, "git://github.com/extend/cowboy.git", "master"}}
+        {cowboy, "0.5.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.5.0_changes_080412"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -13,5 +13,6 @@
 {deps, [
         %{cowboy, ".*", {git, "git://github.com/extend/cowboy.git", "master"}}
         %{cowboy, "0.6.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.6.0_changes_270512"}}}
-        {cowboy, "0.7.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "master"}}}
+        %{cowboy, "0.7.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "master"}}}
+        {cowboy, "0.7.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.7.0_changes_180912"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -14,6 +14,7 @@
         %{cowboy, ".*", {git, "git://github.com/extend/cowboy.git", "master"}}
         %{cowboy, "0.6.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.6.0_changes_270512"}}}
         %{cowboy, "0.7.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "master"}}}
-        {cowboy, "0.7.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.7.0_changes_180912"}}}
+        %{cowboy, "0.7.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.7.0_changes_180912"}}}
         %{cowboy, ".*", {git, "git://github.com/extend/cowboy.git"}}
+        {cowboy, "0.8.3",{git, "https://github.com/extend/cowboy.git"}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
 
 {deps, [
         {cowboy, ".*",
-         {git, "git://github.com/extend/cowboy.git", "4fb2a6face6e7d6ff1dd34a02c3bd8b63d972624"}}
+         {git, "git://github.com/extend/cowboy.git", "master"}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,6 @@
 
 {deps, [
         %{cowboy, ".*", {git, "git://github.com/extend/cowboy.git", "master"}}
-        {cowboy, "0.6.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.6.0_changes_270512"}}}
+        %{cowboy, "0.6.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "ori_cowboy_0.6.0_changes_270512"}}}
+        {cowboy, "0.7.0",{git, "git@github.com:nivertech/cowboy.git", {branch, "master"}}}
        ]}.

--- a/src/mochijson2_fork.erl
+++ b/src/mochijson2_fork.erl
@@ -100,8 +100,7 @@
 -type(json_object() :: {struct, [{json_string(), json_term()}]}).
 -type(json_eep18_object() :: {[{json_string(), json_term()}]}).
 -type(json_iolist() :: {json, iolist()}).
--type(json_term() :: json_string() | json_number() | json_array() |
-                    json_object() | json_eep18_object() | json_iolist()).
+-type(json_term() :: json_string() | json_number() | json_array() | json_object() | json_eep18_object() | json_iolist()).
 
 -record(encoder, {handler=null,
                   utf8=false}).

--- a/src/sockjs.erl
+++ b/src/sockjs.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs).
 
 -export([send/2, close/1, close/3, info/1]).

--- a/src/sockjs_action.erl
+++ b/src/sockjs_action.erl
@@ -59,7 +59,7 @@ options(Req, Headers, _Service) ->
 iframe(Req, Headers, #service{sockjs_url = SockjsUrl}) ->
     IFrame = io_lib:format(?IFRAME, [SockjsUrl]),
     MD5 = "\"" ++ binary_to_list(base64:encode(erlang:md5(IFrame))) ++ "\"",
-    {H, Req2} = sockjs_http:header('If-None-Match', Req),
+    {H, Req2} = sockjs_http:header('if-none-match', Req),
     case H of
         MD5 -> sockjs_http:reply(304, Headers, "", Req2);
         _   -> sockjs_http:reply(

--- a/src/sockjs_action.erl
+++ b/src/sockjs_action.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_action).
 
 % none

--- a/src/sockjs_action.erl
+++ b/src/sockjs_action.erl
@@ -137,10 +137,17 @@ jsonp(Req, Headers, Service, SessionId) ->
 verify_callback(Req, Success) ->
     {CB, Req1} = sockjs_http:callback(Req),
     case CB of
-        undefined ->
-            sockjs_http:reply(500, [], "\"callback\" parameter required", Req1);
+        X when X =:= undefined orelse X =:= [] ->
+            sockjs_http:reply(500, [],
+                              "\"callback\" parameter required", Req1);
         _ ->
-            Success(Req1, CB)
+            case re:run(CB, "[^a-zA-Z0-9-_.]") of
+                {match, _} ->
+                    sockjs_http:reply(500, [],
+                                      "invalid \"callback\" parameter", Req1);
+                nomatch ->
+                    Success(Req1, CB)
+            end
     end.
 
 %% --------------------------------------------------------------------------

--- a/src/sockjs_app.erl
+++ b/src/sockjs_app.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_app).
 
 -behaviour(application).

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_cowboy_handler).
 -behaviour(cowboy_http_handler).
 -behaviour(cowboy_http_websocket_handler).

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -30,7 +30,7 @@ terminate(_Req, _Service) ->
 
 %% --------------------------------------------------------------------------
 
-websocket_init(_TransportName, Req, Service = #service{logger = Logger}) ->
+websocket_init(_TransportName, Req, Service = #service{logger = Logger, hibernate = Hibernate}) ->
     Req0 = Logger(Service, {cowboy, Req}, websocket),
 
     {Info, Req1} = sockjs_handler:extract_info(Req0),
@@ -42,21 +42,35 @@ websocket_init(_TransportName, Req, Service = #service{logger = Logger}) ->
                 {WS, Req2}
         end,
     self() ! go,
-    {ok, Req3, {RawWebsocket, SessionPid}}.
+    case Hibernate of
+        true -> {ok, Req3, {RawWebsocket, SessionPid, Hibernate}, 1000, hibernate};
+        _    -> {ok, Req3, {RawWebsocket, SessionPid, Hibernate}}
+    end.
 
-websocket_handle({text, Data}, Req, {RawWebsocket, SessionPid} = S) ->
+websocket_handle({text, Data}, Req, {RawWebsocket, SessionPid, Hibernate} = S) ->
     case sockjs_ws_handler:received(RawWebsocket, SessionPid, Data) of
-        ok       -> {ok, Req, S};
+        ok       ->
+                    case Hibernate of
+                        true -> {ok, Req, S, hibernate};
+                        _ ->    {ok, Req, S}
+                    end;
         shutdown -> {shutdown, Req, S}
     end;
 websocket_handle(_Unknown, Req, S) ->
     {shutdown, Req, S}.
 
-websocket_info(go, Req, {RawWebsocket, SessionPid} = S) ->
+websocket_info(go, Req, {RawWebsocket, SessionPid, Hibernate} = S) ->
     case sockjs_ws_handler:reply(RawWebsocket, SessionPid) of
-        wait          -> {ok, Req, S};
+        wait          ->
+                         case Hibernate of
+                             true -> {ok, Req, S, hibernate};
+                             _    -> {ok, Req, S}
+                         end;
         {ok, Data}    -> self() ! go,
-                         {reply, {text, Data}, Req, S};
+                         case Hibernate of
+                             true -> {reply, {text, Data}, Req, S, hibernate};
+                             _    -> {reply, {text, Data}, Req, S}
+                         end;
         {close, <<>>} -> {shutdown, Req, S};
         {close, Data} -> self() ! shutdown,
                          {reply, {text, Data}, Req, S}
@@ -64,6 +78,6 @@ websocket_info(go, Req, {RawWebsocket, SessionPid} = S) ->
 websocket_info(shutdown, Req, S) ->
     {shutdown, Req, S}.
 
-websocket_terminate(_Reason, _Req, {RawWebsocket, SessionPid}) ->
+websocket_terminate(_Reason, _Req, {RawWebsocket, SessionPid, _Hibernate}) ->
     sockjs_ws_handler:close(RawWebsocket, SessionPid),
     ok.

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -43,7 +43,7 @@ websocket_init(_TransportName, Req, Service = #service{logger = Logger, hibernat
         end,
     self() ! go,
     case Hibernate of
-        true -> {ok, Req3, {RawWebsocket, SessionPid, Hibernate}, 1000, hibernate};
+        true -> {ok, Req3, {RawWebsocket, SessionPid, Hibernate}, hibernate};
         _    -> {ok, Req3, {RawWebsocket, SessionPid, Hibernate}}
     end.
 

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -1,6 +1,6 @@
 -module(sockjs_cowboy_handler).
 -behaviour(cowboy_http_handler).
--behaviour(cowboy_http_websocket_handler).
+-behaviour(cowboy_websocket_handler).
 
 %% Cowboy http callbacks
 -export([init/3, handle/2, terminate/2]).
@@ -16,7 +16,7 @@
 init({_Any, http}, Req, Service) ->
     case sockjs_handler:is_valid_ws(Service, {cowboy, Req}) of
         {true, {cowboy, _Req1}, _Reason} ->
-            {upgrade, protocol, cowboy_http_websocket};
+            {upgrade, protocol, cowboy_websocket};
         {false, {cowboy, Req1}, _Reason} ->
             {ok, Req1, Service}
     end.

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -73,6 +73,9 @@ websocket_terminate(_Reason, _Req, {RawWebsocket, SessionPid, _HT}) ->
 
 %% --------------------------------------------------------------------------
 
+mh({ok, Req, {RawWebsocket, SessionPid, {TRef, hibernate}}}) ->
+    {ok, Req, {RawWebsocket, SessionPid, {TRef, hibernate}}, hibernate};
+
 mh({ok, Req, {RawWebsocket, SessionPid, {TRef, HibTimeout}}}) ->
     case TRef of
         undefined -> ok;

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -40,8 +40,10 @@ websocket_init(_TransportName, Req,
                Service = #service{logger = Logger, hib_timeout = HibTimeout}) ->
     Req0 = Logger(Service, {cowboy, Req}, websocket),
 
+    Service1 = Service#service{disconnect_delay = 5*60*1000},
+
     {Info, Req1} = sockjs_handler:extract_info(Req0),
-    SessionPid = sockjs_session:maybe_create(undefined, Service, Info),
+    SessionPid = sockjs_session:maybe_create(undefined, Service1, Info),
     {RawWebsocket, {cowboy, Req3}} =
         case sockjs_handler:get_action(Service, Req1) of
             {{match, WS}, Req2} when WS =:= websocket orelse

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -9,7 +9,7 @@
 -behaviour(cowboy_websocket_handler).
 
 %% Cowboy http callbacks
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 %% Cowboy ws callbacks
 -export([websocket_init/3, websocket_handle/3,
@@ -31,7 +31,7 @@ handle(Req, Service) ->
     {cowboy, Req3} = sockjs_handler:handle_req(Service, {cowboy, Req}),
     {ok, Req3, Service}.
 
-terminate(_Req, _Service) ->
+terminate(_Reason, _Req, _Service) ->
     ok.
 
 %% --------------------------------------------------------------------------

--- a/src/sockjs_filters.erl
+++ b/src/sockjs_filters.erl
@@ -38,14 +38,14 @@ h_no_cache(Req, Headers) ->
 
 -spec xhr_cors(req(), headers()) -> {headers(), req()}.
 xhr_cors(Req, Headers) ->
-    {OriginH, Req1} = sockjs_http:header('Origin', Req),
+    {OriginH, Req1} = sockjs_http:header('origin', Req),
      Origin = case OriginH of
                   "null"    -> "*";
                   undefined -> "*";
                   O         -> O
               end,
     {HeadersH, Req2} = sockjs_http:header(
-                             'Access-Control-Request-Headers', Req1),
+                             'access-control-request-headers', Req1),
     AllowHeaders = case HeadersH of
                        undefined -> [];
                        V         -> [{"Access-Control-Allow-Headers", V}]

--- a/src/sockjs_filters.erl
+++ b/src/sockjs_filters.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_filters).
 
 -include("sockjs_internal.hrl").

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -138,13 +138,13 @@ filters() ->
     %% websocket does not actually go via handle_req/3 but we need
     %% something in dispatch/2
     [{t("/websocket"),               [{'GET',     none, websocket,      []}]},
-     {t("/xhr_send"),                [{'POST',    recv, xhr_send,       [h_sid, xhr_cors]},
+     {t("/xhr_send"),                [{'POST',    recv, xhr_send,       [h_sid, h_no_cache, xhr_cors]},
                                       {'OPTIONS', none, options,        OptsFilters}]},
-     {t("/xhr"),                     [{'POST',    send, xhr_polling,    [h_sid, xhr_cors]},
+     {t("/xhr"),                     [{'POST',    send, xhr_polling,    [h_sid, h_no_cache, xhr_cors]},
                                       {'OPTIONS', none, options,        OptsFilters}]},
-     {t("/xhr_streaming"),           [{'POST',    send, xhr_streaming,  [h_sid, xhr_cors]},
+     {t("/xhr_streaming"),           [{'POST',    send, xhr_streaming,  [h_sid, h_no_cache, xhr_cors]},
                                       {'OPTIONS', none, options,        OptsFilters}]},
-     {t("/jsonp_send"),              [{'POST',    recv, jsonp_send,     [h_sid]}]},
+     {t("/jsonp_send"),              [{'POST',    recv, jsonp_send,     [h_sid, h_no_cache]}]},
      {t("/jsonp"),                   [{'GET',     send, jsonp,          [h_sid, h_no_cache]}]},
      {t("/eventsource"),             [{'GET',     send, eventsource,    [h_sid, h_no_cache]}]},
      {t("/htmlfile"),                [{'GET',     send, htmlfile,       [h_sid, h_no_cache]}]},

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -28,6 +28,8 @@ init_state(Prefix, Callback, State, Options) ->
                  proplists:get_value(heartbeat_delay, Options, 25000),
              response_limit =
                  proplists:get_value(response_limit, Options, 128*1024),
+             hibernate =
+                 proplists:get_value(hibernate, Options, false),
              logger =
                  proplists:get_value(logger, Options, fun default_logger/3)
             }.

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -28,8 +28,8 @@ init_state(Prefix, Callback, State, Options) ->
                  proplists:get_value(heartbeat_delay, Options, 25000),
              response_limit =
                  proplists:get_value(response_limit, Options, 128*1024),
-             hibernate =
-                 proplists:get_value(hibernate, Options, false),
+             timeout =
+                 proplists:get_value(timeout, Options, infinity),
              logger =
                  proplists:get_value(logger, Options, fun default_logger/3)
             }.

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -28,8 +28,8 @@ init_state(Prefix, Callback, State, Options) ->
                  proplists:get_value(heartbeat_delay, Options, 25000),
              response_limit =
                  proplists:get_value(response_limit, Options, 128*1024),
-             timeout =
-                 proplists:get_value(timeout, Options, infinity),
+             hib_timeout =
+                 proplists:get_value(hib_timeout, Options, 5000),
              logger =
                  proplists:get_value(logger, Options, fun default_logger/3)
             }.

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -101,11 +101,7 @@ strip_prefix(LongPath, Prefix) ->
     end.
 
 
--type(dispatch_result() ::
-        nomatch |
-        {match, {send | recv | none , atom(),
-                 server(), session(), list(atom())}} |
-        {bad_method, list(atom())}).
+-type(dispatch_result() :: nomatch | {match, {send | recv | none , atom(), server(), session(), list(atom())}} | {bad_method, list(atom())}).
 
 -spec dispatch_req(service(), req()) -> {dispatch_result(), req()}.
 dispatch_req(#service{prefix = Prefix}, Req) ->

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_handler).
 
 -export([init_state/4]).

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -51,7 +51,7 @@ valid_ws_request(_Service, Req) ->
     {R1 and R2, Req2, {R1, R2}}.
 
 valid_ws_upgrade(Req) ->
-    case sockjs_http:header('Upgrade', Req) of
+    case sockjs_http:header('upgrade', Req) of
         {undefined, Req2} ->
             {false, Req2};
         {V, Req2} ->
@@ -64,7 +64,7 @@ valid_ws_upgrade(Req) ->
     end.
 
 valid_ws_connection(Req) ->
-    case sockjs_http:header('Connection', Req) of
+    case sockjs_http:header('connection', Req) of
         {undefined, Req2} ->
             {false, Req2};
         {V, Req2} ->
@@ -220,8 +220,8 @@ extract_info(Req) ->
                                               {V, R1}         -> {[{H, V} | Acc], R1}
                                           end
                                   end, {[], Req2},
-                                  ['Referer', 'X-Client-Ip', 'X-Forwarded-For',
-                                   'X-Cluster-Client-Ip', 'Via', 'X-Real-Ip']),
+                                  ['referer', 'x-client-ip', 'x-forwarded-for',
+                                   'x-cluster-client-ip', 'via', 'x-real-ip']),
     {[{peername, Peer},
       {sockname, Sock},
       {path, Path},

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -7,7 +7,7 @@
 
 -include("sockjs_internal.hrl").
 
--define(SOCKJS_URL, "http://cdn.sockjs.org/sockjs-0.2.js").
+-define(SOCKJS_URL, "http://cdn.sockjs.org/sockjs-0.3.2.min.js").
 
 %% --------------------------------------------------------------------------
 

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -16,13 +16,19 @@ path({cowboy, Req})       -> {Path, Req1} = cowboy_req:path(Req),
 method({cowboy, Req})       -> {Method, Req1} = cowboy_req:method(Req),
                                {method_atom(Method), {cowboy, Req1}}.
 
--spec method_atom(binary()) -> atom().
+-spec method_atom(binary() | atom()) -> atom().
 method_atom(<<"GET">>) -> 'GET';
 method_atom(<<"PUT">>) -> 'PUT';
 method_atom(<<"POST">>) -> 'POST';
 method_atom(<<"DELETE">>) -> 'DELETE';
 method_atom(<<"OPTIONS">>) -> 'OPTIONS';
-method_atom(<<"PATCH">>) -> 'PATCH'.
+method_atom(<<"PATCH">>) -> 'PATCH';
+method_atom('GET') -> 'GET';
+method_atom('PUT') -> 'PUT';
+method_atom('POST') -> 'POST';
+method_atom('DELETE') -> 'DELETE';
+method_atom('OPTIONS') -> 'OPTIONS';
+method_atom('PATCH') -> 'PATCH'.
 
 -spec body(req()) -> {binary(), req()}.
 body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_req:body(Req),

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_http).
 
 -export([path/1, method/1, body/1, body_qs/1, header/2, jsessionid/1,

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -50,7 +50,7 @@ header(K, {cowboy, Req})->
     {H, Req2} = cowboy_http_req:header(K, Req),
     {V, Req3} = case H of
                     undefined ->
-                        cowboy_http_req:header(atom_to_binary(K, utf8), Req2);
+                        cowboy_http_req:header(list_to_binary(atom_to_list(K)), Req2);
                     _ -> {H, Req2}
                 end,
     case V of

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -100,14 +100,7 @@ peername({cowboy, Req}) ->
 
 -spec sockname(req()) -> {{inet:ip_address(), non_neg_integer()}, req()}.
 sockname({cowboy, Req} = R) ->
-    {ok, _T, S} = cowboy_req:transport(Req),
-    %% Cowboy has peername(), but doesn't have sockname() equivalent.
-    {ok, Addr} = case S of
-                     _ when is_port(S) ->
-                         inet:sockname(S);
-                     _ ->
-                         {ok, {{0,0,0,0}, 0}}
-                 end,
+    {Addr, _Req} = cowboy_req:peer(Req),
     {Addr, R}.
 
 %% --------------------------------------------------------------------------

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -29,12 +29,14 @@ method_atom(<<"POST">>) -> 'POST';
 method_atom(<<"DELETE">>) -> 'DELETE';
 method_atom(<<"OPTIONS">>) -> 'OPTIONS';
 method_atom(<<"PATCH">>) -> 'PATCH';
+method_atom(<<"HEAD">>) -> 'HEAD';
 method_atom('GET') -> 'GET';
 method_atom('PUT') -> 'PUT';
 method_atom('POST') -> 'POST';
 method_atom('DELETE') -> 'DELETE';
 method_atom('OPTIONS') -> 'OPTIONS';
-method_atom('PATCH') -> 'PATCH'.
+method_atom('PATCH') -> 'PATCH';
+method_atom('HEAD') -> 'HEAD'.
 
 -spec body(req()) -> {binary(), req()}.
 body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_req:body(Req),

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -133,18 +133,18 @@ enbinary(L) -> [{list_to_binary(K), list_to_binary(V)} || {K, V} <- L].
 
 -spec hook_tcp_close(req()) -> req().
 hook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_req:transport(Req),
+    [T, S] = cowboy_req:get([transport, socket], Req),
     T:setopts(S,[{active,once}]),
     R.
 
 -spec unhook_tcp_close(req()) -> req().
 unhook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_req:transport(Req),
+    [T, S] = cowboy_req:get([transport, socket], Req),
     T:setopts(S,[{active,false}]),
     R.
 
 -spec abruptly_kill(req()) -> req().
 abruptly_kill(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_req:transport(Req),
-    T:close(S),
+    [T, S] = cowboy_req:get([transport, socket], Req),
+    ok = T:close(S),
     R.

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -77,7 +77,7 @@ header(K, {cowboy, Req})->
 
 -spec jsessionid(req()) -> {nonempty_string() | undefined, req()}.
 jsessionid({cowboy, Req}) ->
-    {C, Req2} = cowboy_req:cookie(<<"JSESSIONID">>, Req),
+    {C, Req2} = cowboy_req:cookie(<<"jsessionid">>, Req),
     case C of
         _ when is_binary(C) ->
             {binary_to_list(C), {cowboy, Req2}};

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -9,20 +9,28 @@
 %% --------------------------------------------------------------------------
 
 -spec path(req()) -> {string(), req()}.
-path({cowboy, Req})       -> {Path, Req1} = cowboy_http_req:raw_path(Req),
+path({cowboy, Req})       -> {Path, Req1} = cowboy_req:path(Req),
                              {binary_to_list(Path), {cowboy, Req1}}.
 
 -spec method(req()) -> {atom(), req()}.
-method({cowboy, Req})       -> {Method, Req1} = cowboy_http_req:method(Req),
-                               {Method, {cowboy, Req1}}.
+method({cowboy, Req})       -> {Method, Req1} = cowboy_req:method(Req),
+                               {method_atom(Method), {cowboy, Req1}}.
+
+-spec method_atom(binary()) -> atom().
+method_atom(<<"GET">>) -> 'GET';
+method_atom(<<"PUT">>) -> 'PUT';
+method_atom(<<"POST">>) -> 'POST';
+method_atom(<<"DELETE">>) -> 'DELETE';
+method_atom(<<"OPTIONS">>) -> 'OPTIONS';
+method_atom(<<"PATCH">>) -> 'PATCH'.
 
 -spec body(req()) -> {binary(), req()}.
-body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_http_req:body(Req),
+body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_req:body(Req),
                              {Body, {cowboy, Req1}}.
 
 -spec body_qs(req()) -> {binary(), req()}.
 body_qs(Req) ->
-    {H, Req1} =  header('Content-Type', Req),
+    {H, Req1} =  header('content-type', Req),
     case H of
         H when H =:= "text/plain" orelse H =:= "" ->
             body(Req1);
@@ -31,7 +39,7 @@ body_qs(Req) ->
             body_qs2(Req1)
     end.
 body_qs2({cowboy, Req}) ->
-    {BodyQS, Req1} = cowboy_http_req:body_qs(Req),
+    {ok, BodyQS, Req1} = cowboy_req:body_qs(Req),
     case proplists:get_value(<<"d">>, BodyQS) of
         undefined ->
             {<<>>, {cowboy, Req1}};
@@ -41,10 +49,10 @@ body_qs2({cowboy, Req}) ->
 
 -spec header(atom(), req()) -> {nonempty_string() | undefined, req()}.
 header(K, {cowboy, Req})->
-    {H, Req2} = cowboy_http_req:header(K, Req),
+    {H, Req2} = cowboy_req:header(K, Req),
     {V, Req3} = case H of
                     undefined ->
-                        cowboy_http_req:header(atom_to_binary(K, utf8), Req2);
+                        cowboy_req:header(atom_to_binary(K, utf8), Req2);
                     _ -> {H, Req2}
                 end,
     case V of
@@ -54,7 +62,7 @@ header(K, {cowboy, Req})->
 
 -spec jsessionid(req()) -> {nonempty_string() | undefined, req()}.
 jsessionid({cowboy, Req}) ->
-    {C, Req2} = cowboy_http_req:cookie(<<"JSESSIONID">>, Req),
+    {C, Req2} = cowboy_req:cookie(<<"JSESSIONID">>, Req),
     case C of
         _ when is_binary(C) ->
             {binary_to_list(C), {cowboy, Req2}};
@@ -64,7 +72,7 @@ jsessionid({cowboy, Req}) ->
 
 -spec callback(req()) -> {nonempty_string() | undefined, req()}.
 callback({cowboy, Req}) ->
-    {CB, Req1} = cowboy_http_req:qs_val(<<"c">>, Req),
+    {CB, Req1} = cowboy_req:qs_val(<<"c">>, Req),
     case CB of
         undefined -> {undefined, {cowboy, Req1}};
         _         -> {binary_to_list(CB), {cowboy, Req1}}
@@ -72,12 +80,12 @@ callback({cowboy, Req}) ->
 
 -spec peername(req()) -> {{inet:ip_address(), non_neg_integer()}, req()}.
 peername({cowboy, Req}) ->
-    {P, Req1} = cowboy_http_req:peer(Req),
+    {P, Req1} = cowboy_req:peer(Req),
     {P, {cowboy, Req1}}.
 
 -spec sockname(req()) -> {{inet:ip_address(), non_neg_integer()}, req()}.
 sockname({cowboy, Req} = R) ->
-    {ok, _T, S} = cowboy_http_req:transport(Req),
+    {ok, _T, S} = cowboy_req:transport(Req),
     %% Cowboy has peername(), but doesn't have sockname() equivalent.
     {ok, Addr} = case S of
                      _ when is_port(S) ->
@@ -92,17 +100,17 @@ sockname({cowboy, Req} = R) ->
 -spec reply(non_neg_integer(), headers(), iodata(), req()) -> req().
 reply(Code, Headers, Body, {cowboy, Req}) ->
     Body1 = iolist_to_binary(Body),
-    {ok, Req1} = cowboy_http_req:reply(Code, enbinary(Headers), Body1, Req),
+    {ok, Req1} = cowboy_req:reply(Code, enbinary(Headers), Body1, Req),
     {cowboy, Req1}.
 
 -spec chunk_start(non_neg_integer(), headers(), req()) -> req().
 chunk_start(Code, Headers, {cowboy, Req}) ->
-    {ok, Req1} = cowboy_http_req:chunked_reply(Code, enbinary(Headers), Req),
+    {ok, Req1} = cowboy_req:chunked_reply(Code, enbinary(Headers), Req),
     {cowboy, Req1}.
 
 -spec chunk(iodata(), req()) -> {ok | error, req()}.
 chunk(Chunk, {cowboy, Req} = R) ->
-    case cowboy_http_req:chunk(Chunk, Req) of
+    case cowboy_req:chunk(Chunk, Req) of
         ok          -> {ok, R};
         {error, _E} -> {error, R}
                       %% This shouldn't happen too often, usually we
@@ -117,18 +125,18 @@ enbinary(L) -> [{list_to_binary(K), list_to_binary(V)} || {K, V} <- L].
 
 -spec hook_tcp_close(req()) -> req().
 hook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_http_req:transport(Req),
+    {ok, T, S} = cowboy_req:transport(Req),
     T:setopts(S,[{active,once}]),
     R.
 
 -spec unhook_tcp_close(req()) -> req().
 unhook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_http_req:transport(Req),
+    {ok, T, S} = cowboy_req:transport(Req),
     T:setopts(S,[{active,false}]),
     R.
 
 -spec abruptly_kill(req()) -> req().
 abruptly_kill(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_http_req:transport(Req),
+    {ok, T, S} = cowboy_req:transport(Req),
     T:close(S),
     R.

--- a/src/sockjs_internal.hrl
+++ b/src/sockjs_internal.hrl
@@ -15,6 +15,7 @@
                   disconnect_delay :: non_neg_integer(),
                   heartbeat_delay  :: non_neg_integer(),
                   response_limit   :: non_neg_integer(),
+                  hibernate        :: boolean(),
                   logger           :: logger()
                   }).
 

--- a/src/sockjs_internal.hrl
+++ b/src/sockjs_internal.hrl
@@ -15,7 +15,7 @@
                   disconnect_delay :: non_neg_integer(),
                   heartbeat_delay  :: non_neg_integer(),
                   response_limit   :: non_neg_integer(),
-                  timeout          :: boolean(),
+                  hib_timeout      :: non_neg_integer() | hibernate,
                   logger           :: logger()
                   }).
 

--- a/src/sockjs_internal.hrl
+++ b/src/sockjs_internal.hrl
@@ -15,7 +15,7 @@
                   disconnect_delay :: non_neg_integer(),
                   heartbeat_delay  :: non_neg_integer(),
                   response_limit   :: non_neg_integer(),
-                  hibernate        :: boolean(),
+                  timeout          :: boolean(),
                   logger           :: logger()
                   }).
 

--- a/src/sockjs_internal.hrl
+++ b/src/sockjs_internal.hrl
@@ -7,7 +7,7 @@
 -type(req()          :: {cowboy, any()}).
 
 -type(user_session() :: nonempty_string()).
--type(emittable()    :: init|closed|{recv, binary()}).
+-type(emittable()    :: init|closed|{recv, binary()},{info, any()}).
 -type(callback()     :: fun((user_session(), emittable(), any()) -> ok)).
 -type(logger()       :: fun((any(), req(), websocket|http) -> req())).
 

--- a/src/sockjs_internal.hrl
+++ b/src/sockjs_internal.hrl
@@ -30,9 +30,6 @@
 -type(server()  :: nonempty_string()).
 -type(session() :: nonempty_string()).
 
--type(frame()   :: {open, nil} |
-                   {close, {non_neg_integer(), string()}} |
-                   {data, list(iodata())} |
-                   {heartbeat, nil} ).
+-type(frame()   :: {open, nil} | {close, {non_neg_integer(), string()}} | {data, list(iodata())} | {heartbeat, nil} ).
 
 -type(info()    :: [{atom(), any()}]).

--- a/src/sockjs_internal.hrl
+++ b/src/sockjs_internal.hrl
@@ -7,7 +7,7 @@
 -type(req()          :: {cowboy, any()}).
 
 -type(user_session() :: nonempty_string()).
--type(emittable()    :: init|closed|{recv, binary()},{info, any()}).
+-type(emittable()    :: init|closed|{recv, binary()}|{info, any()}).
 -type(callback()     :: fun((user_session(), emittable(), any()) -> ok)).
 -type(logger()       :: fun((any(), req(), websocket|http) -> req())).
 

--- a/src/sockjs_internal.hrl
+++ b/src/sockjs_internal.hrl
@@ -1,3 +1,8 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
 
 -type(req()          :: {cowboy, any()}).
 

--- a/src/sockjs_json.erl
+++ b/src/sockjs_json.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_json).
 
 -export([encode/1, decode/1]).

--- a/src/sockjs_multiplex.erl
+++ b/src/sockjs_multiplex.erl
@@ -3,7 +3,7 @@
 -behaviour(sockjs_service).
 
 -export([init_state/1]).
--export([sockjs_init/2, sockjs_handle/3, sockjs_terminate/2]).
+-export([sockjs_init/2, sockjs_handle/3, sockjs_terminate/2, sockjs_info/3]).
 
 -record(service, {callback, state, vconn}).
 
@@ -34,6 +34,8 @@ sockjs_terminate(_Conn, {Services, Channels}) ->
             {_Topic, Channel} <- orddict:to_list(Channels) ],
     {ok, {Services, orddict:new()}}.
 
+sockjs_info(_Conn, _Info, {_Services, _Channels} = S) ->
+    {ok, S}.
 
 action(Conn, {Type, Topic, Payload}, Service, Channels) ->
     case {Type, orddict:is_key(Topic, Channels)} of

--- a/src/sockjs_multiplex.erl
+++ b/src/sockjs_multiplex.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_multiplex).
 
 -behaviour(sockjs_service).

--- a/src/sockjs_multiplex_channel.erl
+++ b/src/sockjs_multiplex_channel.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_multiplex_channel, [Conn, Topic]).
 
 -export([send/1, close/0, close/2, info/0]).

--- a/src/sockjs_service.erl
+++ b/src/sockjs_service.erl
@@ -6,7 +6,8 @@ behaviour_info(callbacks) ->
     [
      {sockjs_init, 2},
      {sockjs_handle, 3},
-     {sockjs_terminate, 2}
+     {sockjs_terminate, 2},
+     {sockjs_info, 3}
     ];
 
 behaviour_info(_Other) ->

--- a/src/sockjs_service.erl
+++ b/src/sockjs_service.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_service).
 
 -export([behaviour_info/1]).

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -93,9 +93,8 @@ reply(SessionId, Multiple) ->
 
 cancel_timer_safe(Timer, Atom) ->
     case erlang:cancel_timer(Timer) of
-        false ->
-             receive Atom -> ok
-             after 0 -> ok end;
+        false -> receive Atom -> ok
+                 after   0    -> ok end;
         _ -> ok
     end.
 
@@ -116,7 +115,7 @@ mark_waiting(Pid, State = #session{response_pid    = undefined,
                                    heartbeat_delay = HeartbeatDelay})
   when DisconnectTRef =/= undefined ->
     link(Pid),
-    cancel_timer_safe(DisconnectTRef, session_timeout),
+    _ = cancel_timer_safe(DisconnectTRef, session_timeout),
     TRef = erlang:send_after(HeartbeatDelay, self(), heartbeat_triggered),
     State#session{response_pid    = Pid,
                   disconnect_tref = undefined,
@@ -144,7 +143,7 @@ unmark_waiting(_Pid, State = #session{response_pid     = undefined,
                                       disconnect_tref  = DisconnectTRef,
                                       disconnect_delay = DisconnectDelay})
   when DisconnectTRef =/= undefined ->
-    cancel_timer_safe(DisconnectTRef, session_timeout),
+    _ = cancel_timer_safe(DisconnectTRef, session_timeout),
     TRef = erlang:send_after(DisconnectDelay, self(), session_timeout),
     State#session{disconnect_tref = TRef};
 

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_session).
 
 -behaviour(gen_server).

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -83,13 +83,11 @@ close(Code, Reason, {?MODULE, {SPid, _}}) ->
 info({?MODULE, {_SPid, Info}}) ->
     Info.
 
--spec reply(session_or_pid()) ->
-                   wait | session_in_use | {ok | close, frame()}.
+-spec reply(session_or_pid()) -> wait | session_in_use | {ok | close, frame()}.
 reply(Session) ->
     reply(Session, true).
 
--spec reply(session_or_pid(), boolean()) ->
-                   wait | session_in_use | {ok | close, frame()}.
+-spec reply(session_or_pid(), boolean()) -> wait | session_in_use | {ok | close, frame()}.
 reply(SessionPid, Multiple) when is_pid(SessionPid) ->
     gen_server:call(SessionPid, {reply, self(), Multiple}, infinity);
 reply(SessionId, Multiple) ->

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -292,7 +292,7 @@ handle_info(heartbeat_triggered, State = #session{response_pid = RPid}) when RPi
     RPid ! go,
     {noreply, State#session{heartbeat_tref = triggered}};
 
-handle_info(Info, State = #session{ready_state = open}) ->
+handle_info(Info, State) ->
     State2 = emit({info, Info}, State),
     {noreply, State2}.
 

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -165,7 +165,8 @@ emit(What, State = #session{callback = Callback,
                 case What of
                     init         -> Callback:sockjs_init(Handle, UserState);
                     {recv, Data} -> Callback:sockjs_handle(Handle, Data, UserState);
-                    closed       -> Callback:sockjs_terminate(Handle, UserState)
+                    closed       -> Callback:sockjs_terminate(Handle, UserState);
+                    {info, Info} -> Callback:sockjs_info(Handle, Info, UserState)
                 end
         end,
     case R of
@@ -292,8 +293,9 @@ handle_info(heartbeat_triggered, State = #session{response_pid = RPid}) when RPi
     RPid ! go,
     {noreply, State#session{heartbeat_tref = triggered}};
 
-handle_info(Info, State) ->
-    {stop, {odd_info, Info}, State}.
+handle_info(Info, State = #session{ready_state = open}) ->
+    State2 = emit({info, Info}, State),
+    {noreply, State2}.
 
 
 terminate(_, State = #session{id = SessionId}) ->

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -274,7 +274,9 @@ handle_cast({close, Status, Reason},  State = #session{response_pid = RPid}) ->
 handle_cast(Cast, State) ->
     {stop, {odd_cast, Cast}, State}.
 
-handle_info({message, Raw}, State) ->
+% Allow a handle_info-like call in sockjs handler. 
+% This is useful in cases where we have some main process sending message to processes corresponding to connections.
+handle_info({message, Raw}, State) -> 
     {noreply, emit({message, Raw}, State)};
 
 handle_info({'EXIT', Pid, _Reason},

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -166,6 +166,7 @@ emit(What, State = #session{callback = Callback,
                     init            -> Callback:sockjs_init(Handle, UserState);
                     {recv, Data}    -> Callback:sockjs_handle(Handle, Data, UserState);
                     {message, Data} -> Callback:sockjs_info(Handle, Data, UserState);
+                    tick            -> Callback:sockjs_tick(Handle, Data, UserState);
                     closed          -> Callback:sockjs_terminate(Handle, UserState)
                 end
         end,
@@ -274,10 +275,13 @@ handle_cast({close, Status, Reason},  State = #session{response_pid = RPid}) ->
 handle_cast(Cast, State) ->
     {stop, {odd_cast, Cast}, State}.
 
-% Allow a handle_info-like call in sockjs handler. 
+% Allow a handle_info-like call in sockjs handler. For now only messages of the form {message, X} and tick are supported
 % This is useful in cases where we have some main process sending message to processes corresponding to connections.
 handle_info({message, Raw}, State) -> 
     {noreply, emit({message, Raw}, State)};
+
+handle_info(tick, State) ->
+    {noreply, emit(tick, State)};
 
 handle_info({'EXIT', Pid, _Reason},
             State = #session{response_pid = Pid}) ->

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -166,7 +166,7 @@ emit(What, State = #session{callback = Callback,
                     init            -> Callback:sockjs_init(Handle, UserState);
                     {recv, Data}    -> Callback:sockjs_handle(Handle, Data, UserState);
                     {message, Data} -> Callback:sockjs_info(Handle, Data, UserState);
-                    tick            -> Callback:sockjs_tick(Handle, Data, UserState);
+                    tick            -> Callback:sockjs_tick(Handle, UserState);
                     closed          -> Callback:sockjs_terminate(Handle, UserState)
                 end
         end,

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -275,13 +275,16 @@ handle_cast({close, Status, Reason},  State = #session{response_pid = RPid}) ->
 handle_cast(Cast, State) ->
     {stop, {odd_cast, Cast}, State}.
 
-% Allow a handle_info-like call in sockjs handler. For now only messages of the form {message, X} and tick are supported
+% Allow a handle_info-like call in sockjs handler. For now only messages of the form {message, X}, tick, and force_disconnect are supported
 % This is useful in cases where we have some main process sending message to processes corresponding to connections.
 handle_info({message, Raw}, State) -> 
     {noreply, emit({message, Raw}, State)};
 
 handle_info(tick, State) ->
     {noreply, emit(tick, State)};
+
+handle_info(force_disconnect, State) ->
+    {noreply, emit(force_disconnect, State)};
 
 handle_info({'EXIT', Pid, _Reason},
             State = #session{response_pid = Pid}) ->

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -163,9 +163,10 @@ emit(What, State = #session{callback = Callback,
                 Callback(Handle, What, UserState);
             _ when is_atom(Callback) ->
                 case What of
-                    init         -> Callback:sockjs_init(Handle, UserState);
-                    {recv, Data} -> Callback:sockjs_handle(Handle, Data, UserState);
-                    closed       -> Callback:sockjs_terminate(Handle, UserState)
+                    init            -> Callback:sockjs_init(Handle, UserState);
+                    {recv, Data}    -> Callback:sockjs_handle(Handle, Data, UserState);
+                    {message, Data} -> Callback:sockjs_info(Handle, Data, UserState)
+                    closed          -> Callback:sockjs_terminate(Handle, UserState)
                 end
         end,
     case R of
@@ -273,6 +274,8 @@ handle_cast({close, Status, Reason},  State = #session{response_pid = RPid}) ->
 handle_cast(Cast, State) ->
     {stop, {odd_cast, Cast}, State}.
 
+handle_info({message, Raw}, State) ->
+    {noreply, emit({message, Raw}, State)};
 
 handle_info({'EXIT', Pid, _Reason},
             State = #session{response_pid = Pid}) ->

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -165,8 +165,10 @@ emit(What, State = #session{callback = Callback,
                 case What of
                     init            -> Callback:sockjs_init(Handle, UserState);
                     {recv, Data}    -> Callback:sockjs_handle(Handle, Data, UserState);
-                    {message, Data} -> Callback:sockjs_info(Handle, Data, UserState);
-                    tick            -> Callback:sockjs_tick(Handle, UserState);
+                    {message, Data} -> Callback:sockjs_info(Handle, What, UserState);
+                    {messages, Data}-> Callback:sockjs_info(Handle, What, UserState);
+                    tick            -> Callback:sockjs_info(Handle, What, UserState);
+                    force_disconnect-> Callback:sockjs_info(Handle, What, UserState);
                     closed          -> Callback:sockjs_terminate(Handle, UserState)
                 end
         end,
@@ -275,10 +277,13 @@ handle_cast({close, Status, Reason},  State = #session{response_pid = RPid}) ->
 handle_cast(Cast, State) ->
     {stop, {odd_cast, Cast}, State}.
 
-% Allow a handle_info-like call in sockjs handler. For now only messages of the form {message, X}, tick, and force_disconnect are supported
+% Allow a handle_info-like call in sockjs handler. For now only messages of the form {message, X}, {messages, X}, tick, and force_disconnect are supported
 % This is useful in cases where we have some main process sending message to processes corresponding to connections.
 handle_info({message, Raw}, State) -> 
     {noreply, emit({message, Raw}, State)};
+
+handle_info({messages, Raw}, State) -> 
+    {noreply, emit({messages, Raw}, State)};
 
 handle_info(tick, State) ->
     {noreply, emit(tick, State)};

--- a/src/sockjs_session.erl
+++ b/src/sockjs_session.erl
@@ -165,7 +165,7 @@ emit(What, State = #session{callback = Callback,
                 case What of
                     init            -> Callback:sockjs_init(Handle, UserState);
                     {recv, Data}    -> Callback:sockjs_handle(Handle, Data, UserState);
-                    {message, Data} -> Callback:sockjs_info(Handle, Data, UserState)
+                    {message, Data} -> Callback:sockjs_info(Handle, Data, UserState);
                     closed          -> Callback:sockjs_terminate(Handle, UserState)
                 end
         end,

--- a/src/sockjs_session_sup.erl
+++ b/src/sockjs_session_sup.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_session_sup).
 
 -behaviour(supervisor).

--- a/src/sockjs_util.erl
+++ b/src/sockjs_util.erl
@@ -3,6 +3,7 @@
 -export([rand32/0]).
 -export([encode_frame/1]).
 -export([url_escape/2]).
+-export([cancel_send_after/2]).
 
 -include("sockjs_internal.hrl").
 
@@ -46,3 +47,11 @@ hex(C) ->
     High = integer_to_list(High0),
     Low = integer_to_list(Low0),
     "%" ++ High ++ Low.
+
+-spec cancel_send_after(reference(), atom()) -> ok.
+cancel_send_after(Timer, Atom) ->
+    case erlang:cancel_timer(Timer) of
+        false -> receive Atom -> ok
+                 after   0    -> ok end;
+        _ -> ok
+    end.

--- a/src/sockjs_util.erl
+++ b/src/sockjs_util.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_util).
 
 -export([rand32/0]).

--- a/src/sockjs_ws_handler.erl
+++ b/src/sockjs_ws_handler.erl
@@ -1,3 +1,9 @@
+%% ***** BEGIN LICENSE BLOCK *****
+%% Copyright (c) 2011-2012 VMware, Inc.
+%%
+%% For the license see COPYING.
+%% ***** END LICENSE BLOCK *****
+
 -module(sockjs_ws_handler).
 
 -export([received/3, reply/2, close/2]).


### PR DESCRIPTION
Current master now passes all unit-test from sockjs-protocol-0.3.3.py cleanly.

(except for WebsocketHixie76 where support got removed in cowboy 0.8)
see https://github.com/extend/cowboy/blob/master/CHANGELOG.md
