### PR TITLE
Add Cowboy 0.8.x Support - Clean Patch Series

### DIFF
--- a/examples/cowboy_echo.erl
+++ b/examples/cowboy_echo.erl
@@ -6,7 +6,7 @@
 -export([main/1]).
 
 %% Cowboy callbacks
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 
 main(_) ->
@@ -19,14 +19,15 @@ main(_) ->
     SockjsState = sockjs_handler:init_state(
                     <<"/echo">>, fun service_echo/3, state, []),
 
-    VhostRoutes = [{[<<"echo">>, '...'], sockjs_cowboy_handler, SockjsState},
+    VhostRoutes = [{<<"/echo/[...]">>, sockjs_cowboy_handler, SockjsState},
                    {'_', ?MODULE, []}],
     Routes = [{'_',  VhostRoutes}], % any vhost
+    Dispatch = cowboy_router:compile(Routes),
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
     cowboy:start_http(cowboy_echo_http_listener, 100, 
                       [{port, Port}],
-                      [{dispatch, Routes}]),
+                      [{env, [{dispatch, Dispatch}]}]),
     receive
         _ -> ok
     end.
@@ -42,11 +43,12 @@ handle(Req, State) ->
                                        Data, Req),
     {ok, Req1, State}.
 
-terminate(_Req, _State) ->
+terminate(_Reason, _Req, _State) ->
     ok.
 
 %% --------------------------------------------------------------------------
 
 service_echo(_Conn, init, state)        -> {ok, state};
 service_echo(Conn, {recv, Data}, state) -> Conn:send(Data);
+service_echo(_Conn, {info, _Info}, state) -> {ok, state};
 service_echo(_Conn, closed, state)      -> {ok, state}.

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -1,5 +1,5 @@
 #!/usr/bin/env escript
-%%! -smp disable +A1 +K true -pa ebin deps/cowboy/ebin -input
+%%! -smp disable +A1 +K true -pa ebin -env ERL_LIBS deps -input
 -module(cowboy_test_server).
 -mode(compile).
 
@@ -11,8 +11,10 @@
 
 main(_) ->
     Port = 8081,
-    application:start(sockjs),
-    application:start(cowboy),
+    ok = application:start(sockjs),
+    ok = application:start(ranch),
+    ok = application:start(crypto),    
+    ok = application:start(cowboy),
 
     StateEcho = sockjs_handler:init_state(
                   <<"/echo">>, fun service_echo/3, state,
@@ -42,9 +44,10 @@ main(_) ->
     Routes = [{'_',  VRoutes}], % any vhost
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
-    cowboy:start_listener(http, 100,
-                          cowboy_tcp_transport, [{port,     Port}],
-                          cowboy_http_protocol, [{dispatch, Routes}]),
+
+    cowboy:start_http(cowboy_test_server_http_listener, 100, 
+                      [{port, Port}],
+                      [{dispatch, Routes}]),
     receive
         _ -> ok
     end.
@@ -55,7 +58,7 @@ init({_Any, http}, Req, []) ->
     {ok, Req, []}.
 
 handle(Req, State) ->
-    {ok, Req2} = cowboy_http_req:reply(404, [],
+    {ok, Req2} = cowboy_req:reply(404, [],
                  <<"404 - Nothing here (via sockjs-erlang fallback)\n">>, Req),
     {ok, Req2, State}.
 

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -32,22 +32,23 @@ main(_) ->
                     <<"/cookie_needed_echo">>, fun service_echo/3, state,
                     [{cookie_needed, true}]),
 
-    VRoutes = [{[<<"echo">>, '...'], sockjs_cowboy_handler, StateEcho},
-               {[<<"close">>, '...'], sockjs_cowboy_handler, StateClose},
-               {[<<"amplify">>, '...'], sockjs_cowboy_handler, StateAmplify},
-               {[<<"broadcast">>, '...'], sockjs_cowboy_handler, StateBroadcast},
-               {[<<"disabled_websocket_echo">>, '...'], sockjs_cowboy_handler,
+    VRoutes = [{<<"/echo/[...]">>, sockjs_cowboy_handler, StateEcho},
+               {<<"/close/[...]">>, sockjs_cowboy_handler, StateClose},
+               {<<"/amplify/[...]">>, sockjs_cowboy_handler, StateAmplify},
+               {<<"/broadcast/[...]">>, sockjs_cowboy_handler, StateBroadcast},
+               {<<"/disabled_websocket_echo/[...]">>, sockjs_cowboy_handler,
                 StateDWSEcho},
-               {[<<"cookie_needed_echo">>, '...'], sockjs_cowboy_handler,
+               {<<"/cookie_needed_echo/[...]">>, sockjs_cowboy_handler,
                 StateCNEcho},
                {'_', ?MODULE, []}],
     Routes = [{'_',  VRoutes}], % any vhost
+    Dispatch = cowboy_router:compile(Routes),
 
     io:format(" [*] Running at http://localhost:~p~n", [Port]),
 
     cowboy:start_http(cowboy_test_server_http_listener, 100, 
                       [{port, Port}],
-                      [{dispatch, Routes}]),
+                      [{env, [{dispatch, Dispatch}]}]),
     receive
         _ -> ok
     end.

--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,5 @@
 
 {deps, [
         {cowboy, ".*",
-         {git, "git://github.com/extend/cowboy.git", "4fb2a6face6e7d6ff1dd34a02c3bd8b63d972624"}}
+         {git, "git://github.com/extend/cowboy.git"}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,8 +4,8 @@
 
 {erl_opts, [
             %% fail_on_warning,
-            bin_opt_info,
-            warn_missing_spec,
+            %bin_opt_info,
+            %warn_missing_spec,
             debug_info,
             warn_export_all
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,6 +11,5 @@
 ]}.
 
 {deps, [
-        {cowboy, ".*",
-         {git, "git://github.com/extend/cowboy.git"}}
+        {cowboy, "0.8.3",{git, "https://github.com/extend/cowboy.git", "0.8.3"}}
        ]}.

--- a/src/sockjs_action.erl
+++ b/src/sockjs_action.erl
@@ -59,7 +59,7 @@ options(Req, Headers, _Service) ->
 iframe(Req, Headers, #service{sockjs_url = SockjsUrl}) ->
     IFrame = io_lib:format(?IFRAME, [SockjsUrl]),
     MD5 = "\"" ++ binary_to_list(base64:encode(erlang:md5(IFrame))) ++ "\"",
-    {H, Req2} = sockjs_http:header('If-None-Match', Req),
+    {H, Req2} = sockjs_http:header('if-none-match', Req),
     case H of
         MD5 -> sockjs_http:reply(304, Headers, "", Req2);
         _   -> sockjs_http:reply(

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -3,7 +3,7 @@
 -behaviour(cowboy_websocket_handler).
 
 %% Cowboy http callbacks
--export([init/3, handle/2, terminate/2]).
+-export([init/3, handle/2, terminate/3]).
 
 %% Cowboy ws callbacks
 -export([websocket_init/3, websocket_handle/3,
@@ -25,7 +25,7 @@ handle(Req, Service) ->
     {cowboy, Req3} = sockjs_handler:handle_req(Service, {cowboy, Req}),
     {ok, Req3, Service}.
 
-terminate(_Req, _Service) ->
+terminate(_Reason, _Req, _Service) ->
     ok.
 
 %% --------------------------------------------------------------------------

--- a/src/sockjs_cowboy_handler.erl
+++ b/src/sockjs_cowboy_handler.erl
@@ -1,6 +1,6 @@
 -module(sockjs_cowboy_handler).
 -behaviour(cowboy_http_handler).
--behaviour(cowboy_http_websocket_handler).
+-behaviour(cowboy_websocket_handler).
 
 %% Cowboy http callbacks
 -export([init/3, handle/2, terminate/2]).
@@ -16,7 +16,7 @@
 init({_Any, http}, Req, Service) ->
     case sockjs_handler:is_valid_ws(Service, {cowboy, Req}) of
         {true, {cowboy, _Req1}, _Reason} ->
-            {upgrade, protocol, cowboy_http_websocket};
+            {upgrade, protocol, cowboy_websocket};
         {false, {cowboy, Req1}, _Reason} ->
             {ok, Req1, Service}
     end.

--- a/src/sockjs_filters.erl
+++ b/src/sockjs_filters.erl
@@ -38,14 +38,14 @@ h_no_cache(Req, Headers) ->
 
 -spec xhr_cors(req(), headers()) -> {headers(), req()}.
 xhr_cors(Req, Headers) ->
-    {OriginH, Req1} = sockjs_http:header('Origin', Req),
+    {OriginH, Req1} = sockjs_http:header('origin', Req),
      Origin = case OriginH of
                   "null"    -> "*";
                   undefined -> "*";
                   O         -> O
               end,
     {HeadersH, Req2} = sockjs_http:header(
-                             'Access-Control-Request-Headers', Req1),
+                             'access-control-request-headers', Req1),
     AllowHeaders = case HeadersH of
                        undefined -> [];
                        V         -> [{"Access-Control-Allow-Headers", V}]

--- a/src/sockjs_handler.erl
+++ b/src/sockjs_handler.erl
@@ -51,7 +51,7 @@ valid_ws_request(_Service, Req) ->
     {R1 and R2, Req2, {R1, R2}}.
 
 valid_ws_upgrade(Req) ->
-    case sockjs_http:header('Upgrade', Req) of
+    case sockjs_http:header('upgrade', Req) of
         {undefined, Req2} ->
             {false, Req2};
         {V, Req2} ->
@@ -64,7 +64,7 @@ valid_ws_upgrade(Req) ->
     end.
 
 valid_ws_connection(Req) ->
-    case sockjs_http:header('Connection', Req) of
+    case sockjs_http:header('connection', Req) of
         {undefined, Req2} ->
             {false, Req2};
         {V, Req2} ->
@@ -220,8 +220,8 @@ extract_info(Req) ->
                                               {V, R1}         -> {[{H, V} | Acc], R1}
                                           end
                                   end, {[], Req2},
-                                  ['Referer', 'X-Client-Ip', 'X-Forwarded-For',
-                                   'X-Cluster-Client-Ip', 'Via', 'X-Real-Ip']),
+                                  ['referer', 'x-client-ip', 'x-forwarded-for',
+                                   'x-cluster-client-ip', 'via', 'x-real-ip']),
     {[{peername, Peer},
       {sockname, Sock},
       {path, Path},

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -93,14 +93,7 @@ peername({cowboy, Req}) ->
 
 -spec sockname(req()) -> {{inet:ip_address(), non_neg_integer()}, req()}.
 sockname({cowboy, Req} = R) ->
-    {ok, _T, S} = cowboy_req:transport(Req),
-    %% Cowboy has peername(), but doesn't have sockname() equivalent.
-    {ok, Addr} = case S of
-                     _ when is_port(S) ->
-                         inet:sockname(S);
-                     _ ->
-                         {ok, {{0,0,0,0}, 0}}
-                 end,
+    {Addr, _Req} = cowboy_req:peer(Req),
     {Addr, R}.
 
 %% --------------------------------------------------------------------------

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -126,18 +126,18 @@ enbinary(L) -> [{list_to_binary(K), list_to_binary(V)} || {K, V} <- L].
 
 -spec hook_tcp_close(req()) -> req().
 hook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_req:transport(Req),
+    [T, S] = cowboy_req:get([transport, socket], Req),
     T:setopts(S,[{active,once}]),
     R.
 
 -spec unhook_tcp_close(req()) -> req().
 unhook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_req:transport(Req),
+    [T, S] = cowboy_req:get([transport, socket], Req),
     T:setopts(S,[{active,false}]),
     R.
 
 -spec abruptly_kill(req()) -> req().
 abruptly_kill(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_req:transport(Req),
-    T:close(S),
+    [T, S] = cowboy_req:get([transport, socket], Req),
+    ok = T:close(S),
     R.

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -16,13 +16,19 @@ path({cowboy, Req})       -> {Path, Req1} = cowboy_req:path(Req),
 method({cowboy, Req})       -> {Method, Req1} = cowboy_req:method(Req),
                                {method_atom(Method), {cowboy, Req1}}.
 
--spec method_atom(binary()) -> atom().
+-spec method_atom(binary() | atom()) -> atom().
 method_atom(<<"GET">>) -> 'GET';
 method_atom(<<"PUT">>) -> 'PUT';
 method_atom(<<"POST">>) -> 'POST';
 method_atom(<<"DELETE">>) -> 'DELETE';
 method_atom(<<"OPTIONS">>) -> 'OPTIONS';
-method_atom(<<"PATCH">>) -> 'PATCH'.
+method_atom(<<"PATCH">>) -> 'PATCH';
+method_atom('GET') -> 'GET';
+method_atom('PUT') -> 'PUT';
+method_atom('POST') -> 'POST';
+method_atom('DELETE') -> 'DELETE';
+method_atom('OPTIONS') -> 'OPTIONS';
+method_atom('PATCH') -> 'PATCH'.
 
 -spec body(req()) -> {binary(), req()}.
 body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_req:body(Req),

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -70,7 +70,7 @@ header(K, {cowboy, Req})->
 
 -spec jsessionid(req()) -> {nonempty_string() | undefined, req()}.
 jsessionid({cowboy, Req}) ->
-    {C, Req2} = cowboy_req:cookie(<<"JSESSIONID">>, Req),
+    {C, Req2} = cowboy_req:cookie(<<"jsessionid">>, Req),
     case C of
         _ when is_binary(C) ->
             {binary_to_list(C), {cowboy, Req2}};

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -23,12 +23,14 @@ method_atom(<<"POST">>) -> 'POST';
 method_atom(<<"DELETE">>) -> 'DELETE';
 method_atom(<<"OPTIONS">>) -> 'OPTIONS';
 method_atom(<<"PATCH">>) -> 'PATCH';
+method_atom(<<"HEAD">>) -> 'HEAD';
 method_atom('GET') -> 'GET';
 method_atom('PUT') -> 'PUT';
 method_atom('POST') -> 'POST';
 method_atom('DELETE') -> 'DELETE';
 method_atom('OPTIONS') -> 'OPTIONS';
-method_atom('PATCH') -> 'PATCH'.
+method_atom('PATCH') -> 'PATCH';
+method_atom('HEAD') -> 'HEAD'.
 
 -spec body(req()) -> {binary(), req()}.
 body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_req:body(Req),

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -9,23 +9,28 @@
 %% --------------------------------------------------------------------------
 
 -spec path(req()) -> {string(), req()}.
-path({cowboy, Req})       -> {Path, Req1} = cowboy_http_req:raw_path(Req),
+path({cowboy, Req})       -> {Path, Req1} = cowboy_req:path(Req),
                              {binary_to_list(Path), {cowboy, Req1}}.
 
 -spec method(req()) -> {atom(), req()}.
-method({cowboy, Req})       -> {Method, Req1} = cowboy_http_req:method(Req),
-                               case is_binary(Method) of
-                                   true  -> {binary_to_atom(Method, utf8), {cowboy, Req1}};
-                                   false -> {Method, {cowboy, Req1}}
-                               end.
+method({cowboy, Req})       -> {Method, Req1} = cowboy_req:method(Req),
+                               {method_atom(Method), {cowboy, Req1}}.
+
+-spec method_atom(binary()) -> atom().
+method_atom(<<"GET">>) -> 'GET';
+method_atom(<<"PUT">>) -> 'PUT';
+method_atom(<<"POST">>) -> 'POST';
+method_atom(<<"DELETE">>) -> 'DELETE';
+method_atom(<<"OPTIONS">>) -> 'OPTIONS';
+method_atom(<<"PATCH">>) -> 'PATCH'.
 
 -spec body(req()) -> {binary(), req()}.
-body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_http_req:body(Req),
+body({cowboy, Req})       -> {ok, Body, Req1} = cowboy_req:body(Req),
                              {Body, {cowboy, Req1}}.
 
 -spec body_qs(req()) -> {binary(), req()}.
 body_qs(Req) ->
-    {H, Req1} =  header('Content-Type', Req),
+    {H, Req1} =  header('content-type', Req),
     case H of
         H when H =:= "text/plain" orelse H =:= "" ->
             body(Req1);
@@ -34,7 +39,7 @@ body_qs(Req) ->
             body_qs2(Req1)
     end.
 body_qs2({cowboy, Req}) ->
-    {BodyQS, Req1} = cowboy_http_req:body_qs(Req),
+    {ok, BodyQS, Req1} = cowboy_req:body_qs(Req),
     case proplists:get_value(<<"d">>, BodyQS) of
         undefined ->
             {<<>>, {cowboy, Req1}};
@@ -44,10 +49,10 @@ body_qs2({cowboy, Req}) ->
 
 -spec header(atom(), req()) -> {nonempty_string() | undefined, req()}.
 header(K, {cowboy, Req})->
-    {H, Req2} = cowboy_http_req:header(K, Req),
+    {H, Req2} = cowboy_req:header(K, Req),
     {V, Req3} = case H of
                     undefined ->
-                        cowboy_http_req:header(atom_to_binary(K, utf8), Req2);
+                        cowboy_req:header(atom_to_binary(K, utf8), Req2);
                     _ -> {H, Req2}
                 end,
     case V of
@@ -57,7 +62,7 @@ header(K, {cowboy, Req})->
 
 -spec jsessionid(req()) -> {nonempty_string() | undefined, req()}.
 jsessionid({cowboy, Req}) ->
-    {C, Req2} = cowboy_http_req:cookie(<<"JSESSIONID">>, Req),
+    {C, Req2} = cowboy_req:cookie(<<"JSESSIONID">>, Req),
     case C of
         _ when is_binary(C) ->
             {binary_to_list(C), {cowboy, Req2}};
@@ -67,7 +72,7 @@ jsessionid({cowboy, Req}) ->
 
 -spec callback(req()) -> {nonempty_string() | undefined, req()}.
 callback({cowboy, Req}) ->
-    {CB, Req1} = cowboy_http_req:qs_val(<<"c">>, Req),
+    {CB, Req1} = cowboy_req:qs_val(<<"c">>, Req),
     case CB of
         undefined -> {undefined, {cowboy, Req1}};
         _         -> {binary_to_list(CB), {cowboy, Req1}}
@@ -75,12 +80,12 @@ callback({cowboy, Req}) ->
 
 -spec peername(req()) -> {{inet:ip_address(), non_neg_integer()}, req()}.
 peername({cowboy, Req}) ->
-    {P, Req1} = cowboy_http_req:peer(Req),
+    {P, Req1} = cowboy_req:peer(Req),
     {P, {cowboy, Req1}}.
 
 -spec sockname(req()) -> {{inet:ip_address(), non_neg_integer()}, req()}.
 sockname({cowboy, Req} = R) ->
-    {ok, _T, S} = cowboy_http_req:transport(Req),
+    {ok, _T, S} = cowboy_req:transport(Req),
     %% Cowboy has peername(), but doesn't have sockname() equivalent.
     {ok, Addr} = case S of
                      _ when is_port(S) ->
@@ -95,17 +100,17 @@ sockname({cowboy, Req} = R) ->
 -spec reply(non_neg_integer(), headers(), iodata(), req()) -> req().
 reply(Code, Headers, Body, {cowboy, Req}) ->
     Body1 = iolist_to_binary(Body),
-    {ok, Req1} = cowboy_http_req:reply(Code, enbinary(Headers), Body1, Req),
+    {ok, Req1} = cowboy_req:reply(Code, enbinary(Headers), Body1, Req),
     {cowboy, Req1}.
 
 -spec chunk_start(non_neg_integer(), headers(), req()) -> req().
 chunk_start(Code, Headers, {cowboy, Req}) ->
-    {ok, Req1} = cowboy_http_req:chunked_reply(Code, enbinary(Headers), Req),
+    {ok, Req1} = cowboy_req:chunked_reply(Code, enbinary(Headers), Req),
     {cowboy, Req1}.
 
 -spec chunk(iodata(), req()) -> {ok | error, req()}.
 chunk(Chunk, {cowboy, Req} = R) ->
-    case cowboy_http_req:chunk(Chunk, Req) of
+    case cowboy_req:chunk(Chunk, Req) of
         ok          -> {ok, R};
         {error, _E} -> {error, R}
                       %% This shouldn't happen too often, usually we
@@ -120,18 +125,18 @@ enbinary(L) -> [{list_to_binary(K), list_to_binary(V)} || {K, V} <- L].
 
 -spec hook_tcp_close(req()) -> req().
 hook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_http_req:transport(Req),
+    {ok, T, S} = cowboy_req:transport(Req),
     T:setopts(S,[{active,once}]),
     R.
 
 -spec unhook_tcp_close(req()) -> req().
 unhook_tcp_close(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_http_req:transport(Req),
+    {ok, T, S} = cowboy_req:transport(Req),
     T:setopts(S,[{active,false}]),
     R.
 
 -spec abruptly_kill(req()) -> req().
 abruptly_kill(R = {cowboy, Req}) ->
-    {ok, T, S} = cowboy_http_req:transport(Req),
+    {ok, T, S} = cowboy_req:transport(Req),
     T:close(S),
     R.


### PR DESCRIPTION
Clean patch series against current master to support cowboy 0.8.3.
It passes all unit-test from sockjs-protocol-0.3.3.py cleanly.

(except for WebsocketHixie76 where support got removed in cowboy 0.8)
see https://github.com/extend/cowboy/blob/master/CHANGELOG.md
