### PR TITLE
Add module() as a union type of callback()

### DIFF
--- a/src/sockjs_internal.hrl
+++ b/src/sockjs_internal.hrl
@@ -3,7 +3,7 @@
 
 -type(user_session() :: nonempty_string()).
 -type(emittable()    :: init|closed|{recv, binary()}).
--type(callback()     :: fun((user_session(), emittable(), any()) -> ok)).
+-type(callback()     :: module()|fun((user_session(), emittable(), any()) -> ok)).
 -type(logger()       :: fun((any(), req(), websocket|http) -> req())).
 
 -record(service, {prefix           :: nonempty_string(),


### PR DESCRIPTION
According to to sockjs_session:emit/2, the callback can be a module name, which is how our code uses sockjs_handler:init_state/4. The definition of the callback() type as only a fun results in a number of dialyzer warnings, which are resolved by this change.
