### PR TITLE
Cowboy 0.10.0 support and small fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ main(_) ->
     ok = application:start(sockjs),
     ok = application:start(ranch),
     ok = application:start(crypto),
+    ok = application:start(cowlib),
     ok = application:start(cowboy),
 
     SockjsState = sockjs_handler:init_state(

--- a/examples/cowboy_echo.erl
+++ b/examples/cowboy_echo.erl
@@ -15,6 +15,7 @@ main(_) ->
     ok = application:start(sockjs),
     ok = application:start(ranch),
     ok = application:start(crypto),
+    ok = application:start(cowlib),
     ok = application:start(cowboy),
 
     SockjsState = sockjs_handler:init_state(

--- a/examples/cowboy_test_server.erl
+++ b/examples/cowboy_test_server.erl
@@ -14,7 +14,8 @@ main(_) ->
     ok = application:start(xmerl),
     ok = application:start(sockjs),
     ok = application:start(ranch),
-    ok = application:start(crypto),    
+    ok = application:start(crypto),
+    ok = application:start(cowlib),
     ok = application:start(cowboy),
 
     StateEcho = sockjs_handler:init_state(

--- a/rebar.config
+++ b/rebar.config
@@ -11,5 +11,5 @@
 ]}.
 
 {deps, [
-        {cowboy, "0.8.3",{git, "https://github.com/extend/cowboy.git", "0.8.3"}}
+        {cowboy, "0.10.0",{git, "https://github.com/extend/cowboy.git", "0.10.0"}}
        ]}.

--- a/src/sockjs_http.erl
+++ b/src/sockjs_http.erl
@@ -70,7 +70,7 @@ header(K, {cowboy, Req})->
 
 -spec jsessionid(req()) -> {nonempty_string() | undefined, req()}.
 jsessionid({cowboy, Req}) ->
-    {C, Req2} = cowboy_req:cookie(<<"jsessionid">>, Req),
+    {C, Req2} = cowboy_req:cookie(<<"JSESSIONID">>, Req),
     case C of
         _ when is_binary(C) ->
             {binary_to_list(C), {cowboy, Req2}};


### PR DESCRIPTION
Commits for cowboy 0.10.0 support.
And fix for JsessionidCookie.test_xhr sockjs-protocol test. (passed now)

After changes sockjs-protocol tests shows (failures=1, errors=5) all errors and failures in WebsocketHixie76 protocol test:
- WebsocketHixie76.test_broken_json()
- WebsocketHixie76.test_close()
- WebsocketHixie76.test_empty_frame()
- WebsocketHixie76.test_reuseSessionId()
- WebsocketHixie76.test_transport()
- WebsocketHixie76.test_haproxy()

All this errors happens because after returning {upgrade, protocol, cowboy_websocket} in cowboy_handler, Cowboy server answers with error 400. I have no idea why it happens.

But on client side everything works. All sockjs-client tests in Chrome, Safari and Firefox 100% passed. 
